### PR TITLE
fix(middleware): se elimina middleware innnecesario

### DIFF
--- a/src/components/auth/RouteGuard.tsx
+++ b/src/components/auth/RouteGuard.tsx
@@ -32,9 +32,16 @@ export default function RouteGuard({
   const router = useRouter();
   const [isChecking, setIsChecking] = useState(true);
 
+  const useGuestOnly = !user && !guestOnly;
+
   const validLogin = useCallback(() => {
     const isLoggedIn = !!user && !!user.id;
     const userRole = user?.usuario?.rol as RolUsuario;
+
+    if (useGuestOnly) {
+      setIsChecking(false);
+      return router.push("/login");
+    }
 
     if (guestOnly) {
       if (isLoggedIn) {
@@ -71,13 +78,14 @@ export default function RouteGuard({
     router,
     redirectTo,
     redirectIfLoggedIn,
+    useGuestOnly
   ]);
 
   useEffect(() => {
     validLogin();
   }, [validLogin]);
 
-  if (!user) return <AuthLoader />;
+  if (useGuestOnly) return <AuthLoader />;
   if (isChecking) return <AuthLoader />;
 
   return <>{children}</>;


### PR DESCRIPTION
Esta solicitud de extracción actualiza el componente `RouteGuard` para mejorar la gestión de las rutas solo para invitados y los estados de carga de la autenticación. Los cambios principales aclaran la lógica para determinar cuándo mostrar el cargador de autenticación y cuándo redirigir a los usuarios según su estado de autenticación.

Mejoras en la autenticación y la gestión de rutas de invitados:

* Se añadió la constante `useGuestOnly` que determina si la ruta actual solo debe ser accesible para invitados (usuarios no autenticados) y se actualizó la lógica de comprobación de autenticación para usar esta constante.
* Se modificó el componente para que muestre `AuthLoader` cuando `useGuestOnly` es verdadero, en lugar de comprobar la ausencia de un objeto de usuario, lo que garantiza un comportamiento de carga consistente para las rutas solo para invitados.